### PR TITLE
Upgrade to ts-builds 3.2.1 and pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,2 @@
-# Hoist CLI tool binaries from peer dependencies
-public-hoist-pattern[]=*eslint*
-public-hoist-pattern[]=*prettier*
-public-hoist-pattern[]=*vitest*
-public-hoist-pattern[]=typescript
-public-hoist-pattern[]=*rimraf*
-public-hoist-pattern[]=*cross-env*
+# pnpm 11: hoist patterns, overrides, and build approvals now live in pnpm-workspace.yaml.
+# This file is reserved for registry/auth settings only.

--- a/package.json
+++ b/package.json
@@ -89,16 +89,10 @@
     "@types/node": "^22.20.0",
     "cross-env": "^10.1.0",
     "rimraf": "^6.1.3",
-    "ts-builds": "^2.8.2",
+    "ts-builds": "^3.2.1",
     "tsdown": "^0.22.3",
     "tsx": "^4.22.4",
     "vitest": "^4.1.9"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "sqlite3",
-      "keytar"
-    ]
-  },
-  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       ts-builds:
-        specifier: ^2.8.2
-        version: 2.8.2(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(jsdom@26.1.0)(tsdown@0.22.3(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(synckit@0.11.13)))(vite@7.3.1(@types/node@22.20.0)(tsx@4.22.4))
+        specifier: ^3.2.1
+        version: 3.2.1(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(jsdom@26.1.0)(tsdown@0.22.3(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(synckit@0.11.13)))(vite@7.3.1(@types/node@22.20.0)(tsx@4.22.4))
       tsdown:
         specifier: ^0.22.3
         version: 0.22.3(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(synckit@0.11.13))
@@ -2186,6 +2186,7 @@ packages:
     resolution:
       { integrity: sha512-5amtFHWmJz+x0mKcwKJUBm2nKOJjO0MzzuVhrHFnmDWsUqP1VUsTxENoRdGitwoCH/o+MttLmf1/+lvgkYzbiw== }
     engines: { node: ">= 10.0.0" }
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
   aws-sign2@0.7.0:
     resolution:
@@ -5403,9 +5404,10 @@ packages:
     peerDependencies:
       typescript: ">=4.8.4"
 
-  ts-builds@2.8.2:
+  ts-builds@3.2.1:
     resolution:
-      { integrity: sha512-gAnX6NN18S0zbd9a98oVN+7fOs0hwjVDy9QJokkWkwa30DJm7eovJF3gHABYyaOIIUa/34agMlHPgSm/D9/Dkg== }
+      { integrity: sha512-j1J3UKfRQ3Ve1viF/OXP15i6U6KAW/2kwgqjKZ4Ajli+/8tqVwxu49T0Wp7SL71LIWo+XS3iFdmeWJHFQd31cQ== }
+    engines: { node: ">=22" }
     hasBin: true
     peerDependencies:
       tsdown: ^0.x
@@ -10794,7 +10796,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-builds@2.8.2(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(jsdom@26.1.0)(tsdown@0.22.3(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(synckit@0.11.13)))(vite@7.3.1(@types/node@22.20.0)(tsx@4.22.4)):
+  ts-builds@3.2.1(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(jsdom@26.1.0)(tsdown@0.22.3(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(synckit@0.11.13)))(vite@7.3.1(@types/node@22.20.0)(tsx@4.22.4)):
     dependencies:
       "@eslint/js": 10.0.1(eslint@10.5.0)
       "@types/node": 24.10.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,42 @@
+# Hoist CLI tool binaries from peer dependencies (relocated from .npmrc — ignored by pnpm 11)
+publicHoistPattern:
+  - "*eslint*"
+  - "*prettier*"
+  - "*vitest*"
+  - "typescript"
+  - "*rimraf*"
+  - "*cross-env*"
+
+# Approve dependency build scripts (pnpm 11 strictDepBuilds errors on un-approved scripts)
+allowBuilds:
+  sqlite3: true # native addon — genuinely needs its build script
+  keytar: true # native addon — genuinely needs its build script
+  esbuild: false # binary ships via @esbuild/<platform> optional deps; build script not needed
+  sharp: false # prebuilt binary ships via @img/sharp-<platform> optional deps; build script not needed
+  tldjs: false # ships a bundled public-suffix list; build script only refreshes it
+
+# First-party packages: install just-published versions without the 24h minimumReleaseAge wait
+minimumReleaseAgeExclude:
+  - ts-builds
+  - functype
+  - functype-os
+  # Pinned: build-toolchain transitive deps (tsdown → rolldown) published <24h ago.
+  # Safe to prune once these versions cross the 24h minimumReleaseAge window.
+  - "rolldown@1.1.3"
+  - "@rolldown/binding-android-arm64@1.1.3"
+  - "@rolldown/binding-darwin-arm64@1.1.3"
+  - "@rolldown/binding-darwin-x64@1.1.3"
+  - "@rolldown/binding-freebsd-x64@1.1.3"
+  - "@rolldown/binding-linux-arm-gnueabihf@1.1.3"
+  - "@rolldown/binding-linux-arm64-gnu@1.1.3"
+  - "@rolldown/binding-linux-arm64-musl@1.1.3"
+  - "@rolldown/binding-linux-ppc64-gnu@1.1.3"
+  - "@rolldown/binding-linux-s390x-gnu@1.1.3"
+  - "@rolldown/binding-linux-x64-gnu@1.1.3"
+  - "@rolldown/binding-linux-x64-musl@1.1.3"
+  - "@rolldown/binding-openharmony-arm64@1.1.3"
+  - "@rolldown/binding-wasm32-wasi@1.1.3"
+  - "@rolldown/binding-win32-arm64-msvc@1.1.3"
+  - "@rolldown/binding-win32-x64-msvc@1.1.3"
+  - "@napi-rs/wasm-runtime@1.1.6"
+  - "qs@6.15.3"


### PR DESCRIPTION
Migrates from ts-builds 2.x / pnpm 10 to **ts-builds 3.2.1** / **pnpm 11.9.0**.

## Changes
- Bump `ts-builds` `^2.8.2` → `^3.2.1`; `packageManager` → `pnpm@11.9.0`
- Drop the now-ignored `pnpm.onlyBuiltDependencies` field from `package.json`
- Strip inert `public-hoist-pattern[]` lines from `.npmrc` (pnpm 11 ignores them)
- Add `pnpm-workspace.yaml` for settings pnpm 11 reads only here:
  - **`publicHoistPattern`** — relocated from `.npmrc`
  - **`allowBuilds`** — `sqlite3`/`keytar` `true` (native addons that need their build script); `esbuild`/`sharp`/`tldjs` `false` (ship prebuilt binaries/data via optional deps)
  - **`minimumReleaseAgeExclude`** — first-party packages (`ts-builds`, `functype`, `functype-os`) plus pinned build-toolchain transitive deps published <24h ago (`rolldown@1.1.3` + platform bindings, `qs`, `@napi-rs/wasm-runtime`)

## CI
No workflow changes needed — `pnpm/action-setup@v4` reads `packageManager`, so CI installs pnpm 11 automatically. Frozen-lockfile installs use the committed lockfile, which passes pnpm 11's supply-chain policy via the committed `pnpm-workspace.yaml`.

## Verification
- `ts-builds doctor`: **pnpm 11 ready, 0 errors**
- `pnpm validate`: format ✓ · lint ✓ · typecheck ✓ · **112/112 tests** ✓ · build ✓

## Follow-ups (not in this PR)
- **Node 22 → 24 for OIDC publishing** — `publish.yml` uses OIDC provenance with the flaky `npm install -g npm@latest` workaround; Node 24 (npm 11.5.1+) is the real fix.
- The 18 pinned `minimumReleaseAgeExclude` build-toolchain entries can be pruned once those versions cross the 24h window (harmless if left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)