### PR TITLE
Use Node 24 in CI/publish to fix npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        # 24.x matches the publish runtime; validates native addons (sqlite3, keytar) there.
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          # Node 24 ships npm 11.5.1+, which fixes the OIDC trusted-publishing
+          # handshake bug present in Node 22's npm 10.x (npm/cli#8976).
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install system dependencies
@@ -35,9 +37,6 @@ jobs:
 
       - name: Run validation pipeline
         run: pnpm run validate
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Verify package contents
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes the npm OIDC trusted-publishing handshake by moving CI/publish to Node 24.

## Why
`publish.yml` uses OIDC trusted publishing (`id-token: write` + `npm publish --provenance`, no `NODE_AUTH_TOKEN`). On Node 22 (npm 10.x) the OIDC handshake is buggy ([npm/cli#8976](https://github.com/npm/cli/issues/8976)) — the registry returns an obfuscated `404` on PUT *after* sigstore provenance signing succeeds. npm 11.5.1+ (bundled with Node 24) fixes it. The repo was papering over this with an `npm install -g npm@latest` step, which is flaky on the broken hosted-tool-cache npm.

## Changes
- **`publish.yml`** — Node `22.x` → `24.x`; remove the `npm install -g npm@latest` workaround (Node 24 already bundles npm 11.5.1+)
- **`ci.yml`** — add `24.x` to the test matrix (now `[22.x, 24.x]`) so native addons (`sqlite3`, `keytar`) are validated on the publish runtime while keeping 22.x coverage
- **`security.yml`** — Node `22.x` → `24.x` for consistency

`engines` stays `>=18` — consumers are unaffected; this only changes the CI/publish runtime.

## Verification
- All three workflow YAML files parse cleanly
- `pnpm validate` passes locally on Node 22 (the package builds on both runtimes)
- The real proof is the next tag push exercising `publish.yml` on Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)