### PR TITLE
Fix sidecar profile, share one instance across MCP clients, and clean up token DX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-mcp-server",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "MCP server for Joplin",
   "type": "module",
   "main": "dist/index.js",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -25,7 +25,7 @@ Options:
   -h, --help           Show help
 
 Environment Variables:
-  JOPLIN_TOKEN         Joplin API token (required)
+  JOPLIN_TOKEN         API token for external mode; ignored in sidecar mode
   JOPLIN_HOST          Connect to existing Joplin at this host (skips sidecar)
   JOPLIN_PORT          Connect to existing Joplin on this port (skips sidecar)
   JOPLIN_CLI           Path to joplin CLI binary (overrides auto-detection)

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ async function setupConnection(): Promise<{ host: string; port: number; sidecar:
     apiPort: DEFAULT_API_PORT,
     apiToken: joplinToken,
     syncTarget: syncTarget.orUndefined() as SyncTarget | undefined,
+    version: __VERSION__,
   })
 
   // Phase 1: Resolve port (fast — a few HTTP probes).

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,18 +6,20 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { type CallToolRequest, CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
 import fs from "fs"
+import { Option } from "functype"
 import path from "path"
 import { fileURLToPath } from "url"
 
 import { DEFAULT_API_PORT, JoplinSidecar, type SyncTarget } from "./lib/joplin-sidecar.js"
 import parseArgs from "./lib/parse-args.js"
+import { externalTokenMissing, resolveTokenSource } from "./lib/resolve-token.js"
 import { ToolError } from "./lib/tools/index.js"
 import { initializeJoplinManager } from "./server-core.js"
 import { startFastMCPServer } from "./server-fastmcp.js"
 
 // Parse command line arguments
 const parsedArgs = parseArgs()
-const { transport, httpPort, profileDir, syncTarget } = parsedArgs
+const { transport, httpPort, profileDir, syncTarget, explicitToken } = parsedArgs
 
 const isHttpMode = transport === "http"
 
@@ -32,19 +34,26 @@ const externalPort =
     : undefined
 const externalMode = externalHost !== undefined || externalPort !== undefined
 
-// Token is required for external mode, auto-generated for sidecar mode
-if (!process.env.JOPLIN_TOKEN && externalMode) {
+const generateToken = (): string => `mcp-${crypto.randomUUID().replace(/-/g, "").slice(0, 32)}`
+
+const explicitTokenValue = explicitToken.orUndefined()
+const ambientToken = process.env.JOPLIN_TOKEN
+const tokenInput = { externalMode, explicitToken, ambientToken: Option(ambientToken) }
+
+// External mode connects to a Joplin we do not own, so a caller-supplied token is
+// required: an explicit --token first, otherwise the ambient JOPLIN_TOKEN.
+if (externalTokenMissing(tokenInput)) {
   process.stderr.write(
-    "Error: JOPLIN_TOKEN is required in external mode. Use --token <token> or set JOPLIN_TOKEN environment variable.\n",
+    "Error: a token is required in external mode. Use --token <token> or set JOPLIN_TOKEN environment variable.\n",
   )
   process.exit(1)
 }
 
-// In sidecar mode, persist the auto-generated token so the config hash stays stable
-// across restarts, enabling config caching to skip redundant `joplin config` CLI calls.
-const joplinToken = (() => {
-  if (process.env.JOPLIN_TOKEN) return process.env.JOPLIN_TOKEN
-  if (externalMode) return `mcp-${crypto.randomUUID().replace(/-/g, "").slice(0, 32)}`
+// Read the sidecar's own token from its profile, generating and persisting one on
+// first run. Persisting keeps the config hash stable across restarts (so the
+// `joplin config` step can be skipped) and lets other MCP processes on the same
+// profile converge on one shared sidecar.
+const readOrCreateProfileToken = (): string => {
   const tokenPath = path.join(profileDir, ".mcp-token")
   try {
     const saved = fs.readFileSync(tokenPath, "utf-8").trim()
@@ -52,7 +61,7 @@ const joplinToken = (() => {
   } catch {
     // No saved token yet
   }
-  const token = `mcp-${crypto.randomUUID().replace(/-/g, "").slice(0, 32)}`
+  const token = generateToken()
   try {
     fs.mkdirSync(profileDir, { recursive: true })
     fs.writeFileSync(tokenPath, token)
@@ -60,6 +69,28 @@ const joplinToken = (() => {
     // Non-critical — token still works, just won't be cached
   }
   return token
+}
+
+// Token ownership differs by mode (see resolveTokenSource). In sidecar mode an
+// ambient JOPLIN_TOKEN belongs to a different Joplin and is deliberately ignored.
+const tokenResolution = resolveTokenSource(tokenInput)
+if (tokenResolution.ambientIgnored) {
+  process.stderr.write(
+    "Note: ignoring JOPLIN_TOKEN in sidecar mode; the sidecar manages its own token in the profile. " +
+      "Pass --token to set one explicitly, or JOPLIN_HOST/JOPLIN_PORT to connect to an external Joplin.\n",
+  )
+}
+const joplinToken = ((): string => {
+  switch (tokenResolution.source) {
+    case "explicit":
+      return explicitTokenValue ?? generateToken()
+    case "external-env":
+      return ambientToken ?? generateToken()
+    case "external-generated":
+      return generateToken()
+    case "profile":
+      return readOrCreateProfileToken()
+  }
 })()
 
 async function setupConnection(): Promise<{ host: string; port: number; sidecar: JoplinSidecar | undefined }> {

--- a/src/lib/joplin-sidecar.ts
+++ b/src/lib/joplin-sidecar.ts
@@ -78,7 +78,38 @@ const fetchWithTimeout = async (url: string, timeoutMs: number = 5_000): Promise
   }
 }
 
-type PortProbeResult = "free" | "joplin_ours" | "joplin_foreign" | "occupied_other" | "occupied_unresponsive"
+type PortProbeResult =
+  "free" | "joplin_ours" | "joplin_foreign" | "joplin_unowned" | "occupied_other" | "occupied_unresponsive"
+
+const CLIPPER_PID_FILE = "clipper-pid.txt"
+
+const readProfileServerPid = (profileDir: string): Option<number> => {
+  try {
+    const raw = fs.readFileSync(join(profileDir, CLIPPER_PID_FILE), "utf-8").trim()
+    const pid = Number.parseInt(raw, 10)
+    return Number.isInteger(pid) && pid > 0 ? Option(pid) : Option.none()
+  } catch {
+    return Option.none()
+  }
+}
+
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// A Joplin server records its PID inside the profile directory it serves. If our
+// profile has no live PID recorded, then whatever is answering on the port belongs
+// to some other profile — reusing it would silently serve the wrong database.
+const servesOurProfile = (profileDir: string): boolean =>
+  readProfileServerPid(profileDir).fold(
+    () => false,
+    (pid) => isProcessAlive(pid),
+  )
 
 const isConnectionRefused = (err: unknown): boolean => {
   const e = err as { cause?: { code?: string; errors?: Array<{ code?: string }> } }
@@ -87,7 +118,7 @@ const isConnectionRefused = (err: unknown): boolean => {
   return false
 }
 
-const probePort = async (port: number, token: string): Promise<PortProbeResult> => {
+const probePort = async (port: number, token: string, profileDir: string): Promise<PortProbeResult> => {
   try {
     const pingResponse = await fetchWithTimeout(`http://127.0.0.1:${port}/ping`, 3_000)
     const body = await pingResponse.text()
@@ -99,7 +130,9 @@ const probePort = async (port: number, token: string): Promise<PortProbeResult> 
         `http://127.0.0.1:${port}/folders?token=${encodeURIComponent(token)}&limit=1`,
         3_000,
       )
-      if (authResponse.ok) return "joplin_ours"
+      // Accepting our token is not enough: an orphan serving a different profile
+      // answers identically but exposes the wrong (often empty) database.
+      if (authResponse.ok) return servesOurProfile(profileDir) ? "joplin_ours" : "joplin_unowned"
       return "joplin_foreign"
     } catch {
       return "joplin_foreign"
@@ -117,14 +150,24 @@ type PortResolution =
   | { outcome: "free"; port: number; desktopDetected: boolean }
   | { outcome: "exhausted" }
 
-const resolveAvailablePort = async (startPort: number, token: string): Promise<PortResolution> => {
+const resolveAvailablePort = async (startPort: number, token: string, profileDir: string): Promise<PortResolution> => {
   const tryPort = async (port: number, desktopDetected: boolean): Promise<PortResolution> => {
     if (port >= startPort + MAX_PORT_ATTEMPTS) return { outcome: "exhausted" }
-    const status = await probePort(port, token)
+    const status = await probePort(port, token, profileDir)
     if (status === "free") return { outcome: "free", port, desktopDetected }
     if (status === "joplin_ours") return { outcome: "reuse_existing", port, desktopDetected }
+    if (status === "joplin_unowned") {
+      process.stderr.write(
+        `[joplin-sidecar] Port ${port}: Joplin server accepts our token but serves a different profile ` +
+          `(likely an orphan from a previous run), skipping\n`,
+      )
+      return tryPort(port + 1, desktopDetected)
+    }
     if (status === "joplin_foreign") {
-      process.stderr.write(`[joplin-sidecar] Port ${port}: Joplin Desktop detected (different token), skipping\n`)
+      process.stderr.write(
+        `[joplin-sidecar] Port ${port}: another Joplin instance with a different token ` +
+          `(possibly Joplin Desktop), skipping\n`,
+      )
       return tryPort(port + 1, true)
     }
     process.stderr.write(`[joplin-sidecar] Port ${port} occupied (${status}), trying next...\n`)
@@ -213,9 +256,11 @@ const buildSettingsRecord = (config: SidecarConfig): Record<string, string> => {
 
 const runJoplinConfig = async (cli: string, profileDir: string, key: string, value: string): Promise<void> => {
   const cmd = cli.endsWith("npx") ? "npx" : cli
+  // --profile is a global flag: it must precede the subcommand or the CLI
+  // silently ignores it and falls back to the default ~/.config/joplin profile.
   const args = cli.endsWith("npx")
-    ? ["joplin", "config", "--profile", profileDir, key, value]
-    : ["config", "--profile", profileDir, key, value]
+    ? ["joplin", "--profile", profileDir, "config", key, value]
+    : ["--profile", profileDir, "config", key, value]
   await execFileAsync(cmd, args, { encoding: "utf-8", timeout: 30_000, shell: isWindows })
 }
 
@@ -235,9 +280,10 @@ const configureJoplin = async (cli: string, config: SidecarConfig): Promise<Eith
 const spawnServer = (cli: string, config: SidecarConfig): Either<SidecarError, ChildProcess> => {
   try {
     const cmd = cli.endsWith("npx") ? "npx" : cli
+    // --profile must precede the subcommand (see runJoplinConfig).
     const args = cli.endsWith("npx")
-      ? ["joplin", "server", "start", "--profile", config.profileDir]
-      : ["server", "start", "--profile", config.profileDir]
+      ? ["joplin", "--profile", config.profileDir, "server", "start"]
+      : ["--profile", config.profileDir, "server", "start"]
 
     const proc = spawn(cmd, args, {
       stdio: ["ignore", "pipe", "pipe"],
@@ -357,11 +403,14 @@ const writeConfigCache = (profileDir: string, hash: string): void => {
   }
 }
 
+export { isProcessAlive, readProfileServerPid, servesOurProfile }
+
 export class JoplinSidecar {
   private config: SidecarConfig
   private childProcess: ChildProcess | null = null
   private startPromise: Promise<Either<SidecarError, ChildProcess>> | null = null
   private portResolution: PortResolution | null = null
+  private cleanupRegistered = false
 
   constructor(config: Partial<SidecarConfig> & { apiToken: string }) {
     this.config = {
@@ -373,8 +422,55 @@ export class JoplinSidecar {
     }
   }
 
+  // Best-effort synchronous teardown. Only sync work is possible from an "exit"
+  // handler, and we reap the profile's recorded PID as well as our own child so
+  // that a server we lost the handle to does not survive as an orphan.
+  private killChildSync(): void {
+    // Only reap what we spawned. A server we merely reused may be shared with
+    // another MCP process, so tearing it down here is not ours to do.
+    if (!this.childProcess) return
+    try {
+      this.childProcess.kill("SIGTERM")
+    } catch {
+      // already gone
+    }
+    this.reapRecordedServer()
+  }
+
+  // Under the npx launcher our direct child is only a wrapper — the real Joplin
+  // server is a grandchild that outlives it. Reap it via the PID it recorded in
+  // the profile, which is how orphans accumulated across sessions.
+  private reapRecordedServer(): void {
+    readProfileServerPid(this.config.profileDir).fold(
+      () => undefined,
+      (pid) => {
+        if (pid !== process.pid && isProcessAlive(pid)) {
+          try {
+            process.kill(pid, "SIGTERM")
+          } catch {
+            // already gone
+          }
+        }
+        return undefined
+      },
+    )
+  }
+
+  // SIGINT/SIGTERM are handled by the entrypoint; these cover the exit paths it
+  // misses. A SIGKILLed parent runs no handler at all, which is why start-up
+  // refuses to reuse a server that is not serving our profile.
+  private registerCleanup(): void {
+    if (this.cleanupRegistered) return
+    this.cleanupRegistered = true
+    process.once("exit", () => this.killChildSync())
+    process.once("SIGHUP", () => {
+      this.killChildSync()
+      process.exit(0)
+    })
+  }
+
   async resolvePort(): Promise<Either<SidecarError, number>> {
-    const resolution = await resolveAvailablePort(this.config.apiPort, this.config.apiToken)
+    const resolution = await resolveAvailablePort(this.config.apiPort, this.config.apiToken, this.config.profileDir)
     this.portResolution = resolution
     if (resolution.outcome === "exhausted") {
       const lastPort = this.config.apiPort + MAX_PORT_ATTEMPTS - 1
@@ -477,6 +573,7 @@ export class JoplinSidecar {
         (v) => v,
       )
       this.childProcess = proc
+      this.registerCleanup()
       process.stderr.write(`[joplin-sidecar] Server spawned (pid: ${proc.pid})\n`)
     } else {
       process.stderr.write(
@@ -520,6 +617,7 @@ export class JoplinSidecar {
         })
       })
 
+      this.reapRecordedServer()
       this.childProcess = null
       process.stderr.write("[joplin-sidecar] Server stopped\n")
       return Right(true as const)

--- a/src/lib/joplin-sidecar.ts
+++ b/src/lib/joplin-sidecar.ts
@@ -32,6 +32,9 @@ export type SidecarConfig = {
   apiToken: string
   syncTarget?: SyncTarget
   syncInterval?: number
+  // Identifies the release that spawned a sidecar. A running server started by a
+  // different version is replaced rather than reused, so upgrades take effect.
+  version?: string
 }
 
 export type SidecarError = {
@@ -79,7 +82,13 @@ const fetchWithTimeout = async (url: string, timeoutMs: number = 5_000): Promise
 }
 
 type PortProbeResult =
-  "free" | "joplin_ours" | "joplin_foreign" | "joplin_unowned" | "occupied_other" | "occupied_unresponsive"
+  | "free"
+  | "joplin_ours"
+  | "joplin_stale"
+  | "joplin_foreign"
+  | "joplin_unowned"
+  | "occupied_other"
+  | "occupied_unresponsive"
 
 const CLIPPER_PID_FILE = "clipper-pid.txt"
 
@@ -111,6 +120,60 @@ const servesOurProfile = (profileDir: string): boolean =>
     (pid) => isProcessAlive(pid),
   )
 
+const SIDECAR_STAMP_FILE = ".mcp-sidecar.json"
+
+export type SidecarStamp = {
+  version: string
+  identity: string
+}
+
+// Identity of the data a sidecar serves and how it serves it. Deliberately excludes
+// the port, which is resolved dynamically and says nothing about the running server.
+const computeIdentityHash = (config: SidecarConfig): string =>
+  crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        version: config.version ?? "unknown",
+        apiToken: config.apiToken,
+        syncTarget: config.syncTarget,
+        syncInterval: config.syncInterval,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 16)
+
+const readSidecarStamp = (profileDir: string): Option<SidecarStamp> => {
+  try {
+    const raw: unknown = JSON.parse(fs.readFileSync(join(profileDir, SIDECAR_STAMP_FILE), "utf-8"))
+    const stamp = raw as Partial<SidecarStamp>
+    if (typeof stamp.version !== "string" || typeof stamp.identity !== "string") return Option.none()
+    return Option({ version: stamp.version, identity: stamp.identity })
+  } catch {
+    return Option.none()
+  }
+}
+
+const writeSidecarStamp = (profileDir: string, stamp: SidecarStamp): void => {
+  try {
+    fs.writeFileSync(join(profileDir, SIDECAR_STAMP_FILE), JSON.stringify(stamp))
+  } catch {
+    // Non-critical — worst case the next start replaces a reusable server
+  }
+}
+
+export type ReuseVerdict = "reusable" | "stale" | "not-ours"
+
+// Decides whether a Joplin server already serving our profile can be adopted.
+// An unstamped server predates stamping, so it is replaced rather than trusted.
+const inspectRunningSidecar = (profileDir: string, identity: string): ReuseVerdict => {
+  if (!servesOurProfile(profileDir)) return "not-ours"
+  return readSidecarStamp(profileDir).fold(
+    () => "stale",
+    (stamp) => (stamp.identity === identity ? "reusable" : "stale"),
+  )
+}
+
 const isConnectionRefused = (err: unknown): boolean => {
   const e = err as { cause?: { code?: string; errors?: Array<{ code?: string }> } }
   if (e.cause?.code === "ECONNREFUSED") return true
@@ -118,7 +181,12 @@ const isConnectionRefused = (err: unknown): boolean => {
   return false
 }
 
-const probePort = async (port: number, token: string, profileDir: string): Promise<PortProbeResult> => {
+const probePort = async (
+  port: number,
+  token: string,
+  profileDir: string,
+  identity: string,
+): Promise<PortProbeResult> => {
   try {
     const pingResponse = await fetchWithTimeout(`http://127.0.0.1:${port}/ping`, 3_000)
     const body = await pingResponse.text()
@@ -131,8 +199,14 @@ const probePort = async (port: number, token: string, profileDir: string): Promi
         3_000,
       )
       // Accepting our token is not enough: an orphan serving a different profile
-      // answers identically but exposes the wrong (often empty) database.
-      if (authResponse.ok) return servesOurProfile(profileDir) ? "joplin_ours" : "joplin_unowned"
+      // answers identically but exposes the wrong (often empty) database, and a
+      // server left by an older release serves the old code until it is replaced.
+      if (authResponse.ok) {
+        return Match(inspectRunningSidecar(profileDir, identity))
+          .case("reusable", () => "joplin_ours" as const)
+          .case("stale", () => "joplin_stale" as const)
+          .default(() => "joplin_unowned" as const)
+      }
       return "joplin_foreign"
     } catch {
       return "joplin_foreign"
@@ -147,15 +221,22 @@ const probePort = async (port: number, token: string, profileDir: string): Promi
 
 type PortResolution =
   | { outcome: "reuse_existing"; port: number; desktopDetected: boolean }
+  | { outcome: "replace_stale"; port: number; desktopDetected: boolean }
   | { outcome: "free"; port: number; desktopDetected: boolean }
   | { outcome: "exhausted" }
 
-const resolveAvailablePort = async (startPort: number, token: string, profileDir: string): Promise<PortResolution> => {
+const resolveAvailablePort = async (
+  startPort: number,
+  token: string,
+  profileDir: string,
+  identity: string,
+): Promise<PortResolution> => {
   const tryPort = async (port: number, desktopDetected: boolean): Promise<PortResolution> => {
     if (port >= startPort + MAX_PORT_ATTEMPTS) return { outcome: "exhausted" }
-    const status = await probePort(port, token, profileDir)
+    const status = await probePort(port, token, profileDir, identity)
     if (status === "free") return { outcome: "free", port, desktopDetected }
     if (status === "joplin_ours") return { outcome: "reuse_existing", port, desktopDetected }
+    if (status === "joplin_stale") return { outcome: "replace_stale", port, desktopDetected }
     if (status === "joplin_unowned") {
       process.stderr.write(
         `[joplin-sidecar] Port ${port}: Joplin server accepts our token but serves a different profile ` +
@@ -403,7 +484,8 @@ const writeConfigCache = (profileDir: string, hash: string): void => {
   }
 }
 
-export { isProcessAlive, readProfileServerPid, servesOurProfile }
+export { computeIdentityHash, inspectRunningSidecar, isProcessAlive, readProfileServerPid, readSidecarStamp }
+export { servesOurProfile, writeSidecarStamp }
 
 export class JoplinSidecar {
   private config: SidecarConfig
@@ -419,7 +501,51 @@ export class JoplinSidecar {
       apiToken: config.apiToken,
       syncTarget: config.syncTarget,
       syncInterval: config.syncInterval,
+      version: config.version,
     }
+  }
+
+  private identity(): string {
+    return computeIdentityHash(this.config)
+  }
+
+  // True while a Joplin server is serving our profile — whether we spawned it or
+  // adopted one already running.
+  private sidecarAlive(): boolean {
+    return servesOurProfile(this.config.profileDir)
+  }
+
+  // A server left by a different release or a changed sync configuration is torn
+  // down so the current one can take the port. This is how upgrades roll over: a
+  // new version never adopts the previous version's running server.
+  private async replaceStaleServer(port: number): Promise<void> {
+    const previous = readSidecarStamp(this.config.profileDir).fold(
+      () => "unstamped",
+      (s) => `v${s.version}`,
+    )
+    process.stderr.write(
+      `[joplin-sidecar] Replacing sidecar on port ${port} (${previous} -> v${this.config.version ?? "unknown"} ` +
+        `or changed sync config)\n`,
+    )
+    this.reapRecordedServer()
+    await this.waitForPortFree(port)
+  }
+
+  private async waitForPortFree(port: number, maxAttempts: number = 20): Promise<void> {
+    const attempt = async (i: number): Promise<void> => {
+      if (i >= maxAttempts) {
+        process.stderr.write(`[joplin-sidecar] Port ${port} still busy after teardown, continuing anyway\n`)
+        return
+      }
+      try {
+        await fetchWithTimeout(`http://127.0.0.1:${port}/ping`, 1_000)
+      } catch (err: unknown) {
+        if (isConnectionRefused(err)) return
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      return attempt(i + 1)
+    }
+    return attempt(0)
   }
 
   // Best-effort synchronous teardown. Only sync work is possible from an "exit"
@@ -470,7 +596,12 @@ export class JoplinSidecar {
   }
 
   async resolvePort(): Promise<Either<SidecarError, number>> {
-    const resolution = await resolveAvailablePort(this.config.apiPort, this.config.apiToken, this.config.profileDir)
+    const resolution = await resolveAvailablePort(
+      this.config.apiPort,
+      this.config.apiToken,
+      this.config.profileDir,
+      this.identity(),
+    )
     this.portResolution = resolution
     if (resolution.outcome === "exhausted") {
       const lastPort = this.config.apiPort + MAX_PORT_ATTEMPTS - 1
@@ -496,6 +627,15 @@ export class JoplinSidecar {
   }
 
   async start(): Promise<Either<SidecarError, ChildProcess>> {
+    // A shared sidecar can die while we are still running — most often because the
+    // process that spawned it exited. Drop a settled start so the next call really
+    // restarts instead of replaying an earlier success against a dead server.
+    if (this.startPromise && !this.sidecarAlive()) {
+      process.stderr.write("[joplin-sidecar] Sidecar is no longer running, restarting\n")
+      this.startPromise = null
+      this.childProcess = null
+      this.portResolution = null
+    }
     if (this.startPromise) return this.startPromise
     this.startPromise = this.doStart()
     return this.startPromise
@@ -531,12 +671,19 @@ export class JoplinSidecar {
       }
     }
 
-    // Step 3: If we found an existing instance with our token, reuse it
+    // Step 3: Adopt a healthy server serving our profile, so several MCP processes
+    // share one sidecar rather than each spawning its own.
     if (this.portResolution?.outcome === "reuse_existing") {
       process.stderr.write(
-        `[joplin-sidecar] Existing Joplin server with matching token on port ${this.config.apiPort}, reusing\n`,
+        `[joplin-sidecar] Existing Joplin server for this profile on port ${this.config.apiPort}, reusing\n`,
       )
       return Right(this.childProcess ?? (null as unknown as ChildProcess))
+    }
+
+    // Step 3b: A server from a previous release or a changed sync config holds the
+    // port. Tear it down first so this version's sidecar replaces it.
+    if (this.portResolution?.outcome === "replace_stale") {
+      await this.replaceStaleServer(this.config.apiPort)
     }
 
     // Step 4: Configure via CLI (skip if config is cached)
@@ -591,6 +738,13 @@ export class JoplinSidecar {
         ),
       )
     }
+
+    // Step 7: Stamp the profile so other processes can tell whether this running
+    // server matches their release and sync configuration.
+    writeSidecarStamp(this.config.profileDir, {
+      version: this.config.version ?? "unknown",
+      identity: this.identity(),
+    })
 
     return Right(this.childProcess!)
   }

--- a/src/lib/joplin-sidecar.ts
+++ b/src/lib/joplin-sidecar.ts
@@ -128,15 +128,19 @@ export type SidecarStamp = {
   identity: string
 }
 
-// Identity of the data a sidecar serves and how it serves it. Deliberately excludes
-// the port, which is resolved dynamically and says nothing about the running server.
+// Identity captures only what the reuse auth-probe does NOT already verify: the
+// release version and the sync configuration. Token compatibility is proven earlier
+// by the probe (a server holding a different token is rejected as foreign before
+// identity is ever compared), so the token is deliberately excluded — including it
+// would be redundant and would write token-derived data into the on-disk stamp. The
+// port is excluded too, being resolved dynamically and saying nothing about the
+// running server.
 const computeIdentityHash = (config: SidecarConfig): string =>
   crypto
     .createHash("sha256")
     .update(
       JSON.stringify({
         version: config.version ?? "unknown",
-        apiToken: config.apiToken,
         syncTarget: config.syncTarget,
         syncInterval: config.syncInterval,
       }),

--- a/src/lib/joplin-sidecar.ts
+++ b/src/lib/joplin-sidecar.ts
@@ -3,7 +3,8 @@ import crypto from "crypto"
 import fs from "fs"
 import { Either, Left, Match, Option, Right } from "functype"
 import { Platform } from "functype-os"
-import { join } from "path"
+import { dirname, join } from "path"
+import { fileURLToPath } from "url"
 import { promisify } from "util"
 
 const execAsync = promisify(exec)
@@ -257,6 +258,24 @@ const resolveAvailablePort = async (
   return tryPort(startPort, false)
 }
 
+const CLI_BIN_NAME = isWindows ? "joplin.cmd" : "joplin"
+const CLI_SEARCH_DEPTH = 5
+
+// Where a bundled Joplin CLI might live, nearest first. Resolution has to be
+// module-relative: under a packaged install the working directory belongs to the
+// host application, so process.cwd() finds nothing. It stays in the list last so
+// a plain `pnpm dev` from the repo root keeps working.
+const ancestorDirs = (dir: string, remaining: number): string[] => {
+  const parent = dirname(dir)
+  if (remaining <= 0 || parent === dir) return [dir]
+  return [dir, ...ancestorDirs(parent, remaining - 1)]
+}
+
+const localCliCandidates = (): string[] =>
+  [...ancestorDirs(dirname(fileURLToPath(import.meta.url)), CLI_SEARCH_DEPTH), process.cwd()].map((root) =>
+    join(root, "node_modules", ".bin", CLI_BIN_NAME),
+  )
+
 const findJoplinCli = async (): Promise<Either<SidecarError, string>> => {
   // 1. User override via env var
   const envCli = process.env.JOPLIN_CLI
@@ -265,9 +284,9 @@ const findJoplinCli = async (): Promise<Either<SidecarError, string>> => {
     return Left(sidecarError("CLI_NOT_FOUND", `JOPLIN_CLI path not found: ${envCli}`))
   }
 
-  // 2. Bundled in node_modules (if joplin is a dependency)
-  const localBin = join(process.cwd(), "node_modules", ".bin", isWindows ? "joplin.cmd" : "joplin")
-  if (fs.existsSync(localBin)) return Right(localBin)
+  // 2. Bundled in node_modules, resolved relative to this module
+  const bundled = localCliCandidates().find((candidate) => fs.existsSync(candidate))
+  if (bundled) return Right(bundled)
 
   // 3. Global install
   try {
@@ -484,8 +503,8 @@ const writeConfigCache = (profileDir: string, hash: string): void => {
   }
 }
 
-export { computeIdentityHash, inspectRunningSidecar, isProcessAlive, readProfileServerPid, readSidecarStamp }
-export { servesOurProfile, writeSidecarStamp }
+export { computeIdentityHash, inspectRunningSidecar, isProcessAlive, localCliCandidates, readProfileServerPid }
+export { readSidecarStamp, servesOurProfile, writeSidecarStamp }
 
 export class JoplinSidecar {
   private config: SidecarConfig

--- a/src/lib/parse-args.ts
+++ b/src/lib/parse-args.ts
@@ -11,6 +11,10 @@ export type ParsedArgs = {
   httpPort: number
   profileDir: string
   syncTarget: Option<SyncTarget>
+  // A token passed explicitly via --token. Kept distinct from an ambient
+  // JOPLIN_TOKEN so sidecar mode can honor the deliberate flag while ignoring an
+  // inherited environment variable that belongs to a different (external) Joplin.
+  explicitToken: Option<string>
 }
 
 // Local expandVars preserves the existing "silently substitute empty for missing
@@ -204,13 +208,9 @@ function parseArgs(): ParsedArgs {
     (file) => loadEnvFile(resolve(process.cwd(), file)),
   )
 
-  // Handle --token
-  extractArg(args, "--token").fold(
-    () => {},
-    (token) => {
-      process.env.JOPLIN_TOKEN = token
-    },
-  )
+  // Handle --token. Surfaced as an explicit value rather than written into the
+  // environment, so downstream can tell a deliberate flag from an inherited var.
+  const explicitToken = extractArg(args, "--token")
 
   // Handle --transport
   const transport: "stdio" | "http" = extractArg(args, "--transport")
@@ -286,7 +286,8 @@ OPTIONS:
   --help, -h                 Show this help message
 
 ENVIRONMENT VARIABLES:
-  JOPLIN_TOKEN               Joplin API token (required)
+  JOPLIN_TOKEN               API token for external mode (JOPLIN_HOST/JOPLIN_PORT).
+                             Ignored in sidecar mode, which manages its own token.
   JOPLIN_HOST                Connect to existing Joplin at this host (skips sidecar)
   JOPLIN_PORT                Connect to existing Joplin on this port (skips sidecar)
   JOPLIN_CLI                 Path to joplin CLI binary (overrides auto-detection)
@@ -343,6 +344,7 @@ Find your Joplin token in: Tools > Options > Web Clipper
     httpPort,
     profileDir,
     syncTarget: resolvedSyncTarget,
+    explicitToken,
   }
 }
 

--- a/src/lib/resolve-token.ts
+++ b/src/lib/resolve-token.ts
@@ -1,0 +1,41 @@
+import type { Option } from "functype"
+
+export type TokenSource = "explicit" | "external-env" | "external-generated" | "profile"
+
+export type TokenResolution = {
+  // Which channel supplied the token — see TokenSource. Callers use this to know
+  // whether to read/persist the profile token and whether to warn.
+  source: TokenSource
+  // True when an ambient JOPLIN_TOKEN was present but ignored (sidecar mode).
+  ambientIgnored: boolean
+}
+
+export type ResolveTokenInput = {
+  externalMode: boolean
+  explicitToken: Option<string>
+  ambientToken: Option<string>
+}
+
+// Decides where a Joplin token comes from, without performing any I/O.
+//
+// The token means different things per mode. In external mode it is a guest
+// credential for a Joplin we do not own, so a caller must supply it. In sidecar
+// mode we own the instance and mint the token in the profile; an explicit --token
+// still wins, but an ambient JOPLIN_TOKEN is ignored so that several sidecar
+// processes sharing a profile agree on one token without env coordination.
+export const resolveTokenSource = (input: ResolveTokenInput): TokenResolution => {
+  if (input.explicitToken.isEmpty === false) {
+    return { source: "explicit", ambientIgnored: false }
+  }
+  if (input.externalMode) {
+    return {
+      source: input.ambientToken.isEmpty === false ? "external-env" : "external-generated",
+      ambientIgnored: false,
+    }
+  }
+  return { source: "profile", ambientIgnored: input.ambientToken.isEmpty === false }
+}
+
+// External mode requires a caller-supplied token; sidecar mode never does.
+export const externalTokenMissing = (input: ResolveTokenInput): boolean =>
+  input.externalMode && input.explicitToken.isEmpty && input.ambientToken.isEmpty

--- a/tests/unit/resolve-token.test.ts
+++ b/tests/unit/resolve-token.test.ts
@@ -1,0 +1,73 @@
+import { Option } from "functype"
+import { describe, expect, it } from "vitest"
+import { externalTokenMissing, resolveTokenSource } from "../../src/lib/resolve-token.js"
+
+const input = (o: { externalMode: boolean; explicit?: string; ambient?: string }) => ({
+  externalMode: o.externalMode,
+  explicitToken: Option(o.explicit),
+  ambientToken: Option(o.ambient),
+})
+
+describe("resolveTokenSource", () => {
+  describe("sidecar mode", () => {
+    it("uses the profile token when nothing is supplied", () => {
+      const r = resolveTokenSource(input({ externalMode: false }))
+      expect(r.source).toBe("profile")
+      expect(r.ambientIgnored).toBe(false)
+    })
+
+    // The core of the design: an inherited JOPLIN_TOKEN belongs to a different
+    // Joplin and must not override the sidecar's own profile token.
+    it("ignores an ambient JOPLIN_TOKEN and flags it", () => {
+      const r = resolveTokenSource(input({ externalMode: false, ambient: "desktop-token" }))
+      expect(r.source).toBe("profile")
+      expect(r.ambientIgnored).toBe(true)
+    })
+
+    it("honors an explicit --token over the profile", () => {
+      const r = resolveTokenSource(input({ externalMode: false, explicit: "chosen" }))
+      expect(r.source).toBe("explicit")
+      expect(r.ambientIgnored).toBe(false)
+    })
+
+    it("prefers an explicit --token even when an ambient token is present", () => {
+      const r = resolveTokenSource(input({ externalMode: false, explicit: "chosen", ambient: "inherited" }))
+      expect(r.source).toBe("explicit")
+      expect(r.ambientIgnored).toBe(false)
+    })
+  })
+
+  describe("external mode", () => {
+    it("uses the ambient JOPLIN_TOKEN as the guest credential", () => {
+      const r = resolveTokenSource(input({ externalMode: true, ambient: "guest" }))
+      expect(r.source).toBe("external-env")
+      expect(r.ambientIgnored).toBe(false)
+    })
+
+    it("prefers an explicit --token over the ambient one", () => {
+      const r = resolveTokenSource(input({ externalMode: true, explicit: "chosen", ambient: "guest" }))
+      expect(r.source).toBe("explicit")
+    })
+
+    it("falls back to a generated token when none is supplied", () => {
+      const r = resolveTokenSource(input({ externalMode: true }))
+      expect(r.source).toBe("external-generated")
+    })
+  })
+})
+
+describe("externalTokenMissing", () => {
+  it("is true only in external mode with no token from any source", () => {
+    expect(externalTokenMissing(input({ externalMode: true }))).toBe(true)
+  })
+
+  it("is false in external mode when a token is present", () => {
+    expect(externalTokenMissing(input({ externalMode: true, ambient: "guest" }))).toBe(false)
+    expect(externalTokenMissing(input({ externalMode: true, explicit: "chosen" }))).toBe(false)
+  })
+
+  // Sidecar mode always has a fallback (the profile token), so it is never missing.
+  it("is false in sidecar mode regardless of tokens", () => {
+    expect(externalTokenMissing(input({ externalMode: false }))).toBe(false)
+  })
+})

--- a/tests/unit/sidecar-profile.test.ts
+++ b/tests/unit/sidecar-profile.test.ts
@@ -7,6 +7,7 @@ import {
   computeIdentityHash,
   inspectRunningSidecar,
   isProcessAlive,
+  localCliCandidates,
   readProfileServerPid,
   readSidecarStamp,
   servesOurProfile,
@@ -15,6 +16,8 @@ import {
 
 // A PID far above any realistic allocation, used to represent a dead process.
 const DEAD_PID = 4_194_303
+
+const CLI_BIN_NAME = process.platform === "win32" ? "joplin.cmd" : "joplin"
 
 describe("sidecar profile ownership", () => {
   let profileDir: string
@@ -160,6 +163,31 @@ describe("sidecar profile ownership", () => {
       writePid(String(process.pid))
       writeSidecarStamp(profileDir, { version: "2.1.1", identity: "abc123" })
       expect(inspectRunningSidecar(profileDir, "abc123")).toBe("reusable")
+    })
+  })
+
+  describe("localCliCandidates", () => {
+    it("looks for the CLI in node_modules/.bin", () => {
+      const suffix = join("node_modules", ".bin")
+      expect(localCliCandidates().every((p) => p.includes(suffix))).toBe(true)
+    })
+
+    // The packaged-install failure: the host application sets the working
+    // directory, so a cwd-relative lookup finds nothing and the sidecar silently
+    // falls back to downloading the CLI through npx.
+    it("finds the bundled CLI when the working directory is elsewhere", () => {
+      const original = process.cwd()
+      try {
+        process.chdir(os.tmpdir())
+        const found = localCliCandidates().filter((p) => fs.existsSync(p))
+        expect(found.length).toBeGreaterThan(0)
+      } finally {
+        process.chdir(original)
+      }
+    })
+
+    it("still searches the working directory for local development", () => {
+      expect(localCliCandidates()).toContain(join(process.cwd(), "node_modules", ".bin", CLI_BIN_NAME))
     })
   })
 })

--- a/tests/unit/sidecar-profile.test.ts
+++ b/tests/unit/sidecar-profile.test.ts
@@ -2,7 +2,16 @@ import fs from "fs"
 import os from "os"
 import { join } from "path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { isProcessAlive, readProfileServerPid, servesOurProfile } from "../../src/lib/joplin-sidecar.js"
+import type { SidecarConfig } from "../../src/lib/joplin-sidecar.js"
+import {
+  computeIdentityHash,
+  inspectRunningSidecar,
+  isProcessAlive,
+  readProfileServerPid,
+  readSidecarStamp,
+  servesOurProfile,
+  writeSidecarStamp,
+} from "../../src/lib/joplin-sidecar.js"
 
 // A PID far above any realistic allocation, used to represent a dead process.
 const DEAD_PID = 4_194_303
@@ -70,6 +79,87 @@ describe("sidecar profile ownership", () => {
     it("is true when the recorded server is still running", () => {
       writePid(String(process.pid))
       expect(servesOurProfile(profileDir)).toBe(true)
+    })
+  })
+
+  describe("computeIdentityHash", () => {
+    const base: SidecarConfig = {
+      profileDir: "/tmp/example",
+      apiPort: 41184,
+      apiToken: "mcp-token",
+      syncTarget: { type: "filesystem", path: "/data/joplin" },
+      syncInterval: 300,
+      version: "2.1.1",
+    }
+
+    it("is stable for an unchanged configuration", () => {
+      expect(computeIdentityHash(base)).toBe(computeIdentityHash({ ...base }))
+    })
+
+    // The upgrade path: a new release must not adopt the previous release's server.
+    it("changes when the version changes", () => {
+      expect(computeIdentityHash({ ...base, version: "2.2.0" })).not.toBe(computeIdentityHash(base))
+    })
+
+    it("changes when the sync target changes", () => {
+      const moved: SidecarConfig = { ...base, syncTarget: { type: "filesystem", path: "/data/elsewhere" } }
+      expect(computeIdentityHash(moved)).not.toBe(computeIdentityHash(base))
+    })
+
+    it("changes when the token changes", () => {
+      expect(computeIdentityHash({ ...base, apiToken: "mcp-other" })).not.toBe(computeIdentityHash(base))
+    })
+
+    // The port is resolved dynamically and says nothing about what the server serves,
+    // so it must not fragment identity between otherwise-identical processes.
+    it("ignores the api port", () => {
+      expect(computeIdentityHash({ ...base, apiPort: 41190 })).toBe(computeIdentityHash(base))
+    })
+  })
+
+  describe("readSidecarStamp", () => {
+    it("returns none when nothing has been stamped", () => {
+      expect(readSidecarStamp(profileDir).isEmpty).toBe(true)
+    })
+
+    it("returns none for a malformed stamp", () => {
+      fs.writeFileSync(join(profileDir, ".mcp-sidecar.json"), '{"version":2}')
+      expect(readSidecarStamp(profileDir).isEmpty).toBe(true)
+    })
+
+    it("round-trips a written stamp", () => {
+      writeSidecarStamp(profileDir, { version: "2.1.1", identity: "abc123" })
+      const stamp = readSidecarStamp(profileDir).fold(
+        () => null,
+        (v) => v,
+      )
+      expect(stamp).toEqual({ version: "2.1.1", identity: "abc123" })
+    })
+  })
+
+  describe("inspectRunningSidecar", () => {
+    it("reports not-ours when no live server holds the profile", () => {
+      writePid(String(DEAD_PID))
+      writeSidecarStamp(profileDir, { version: "2.1.1", identity: "abc123" })
+      expect(inspectRunningSidecar(profileDir, "abc123")).toBe("not-ours")
+    })
+
+    // Servers predating stamping cannot be vouched for, so they get replaced.
+    it("reports stale when a live server left no stamp", () => {
+      writePid(String(process.pid))
+      expect(inspectRunningSidecar(profileDir, "abc123")).toBe("stale")
+    })
+
+    it("reports stale when the running server has a different identity", () => {
+      writePid(String(process.pid))
+      writeSidecarStamp(profileDir, { version: "2.0.0", identity: "old-identity" })
+      expect(inspectRunningSidecar(profileDir, "abc123")).toBe("stale")
+    })
+
+    it("reports reusable when identity matches a live server", () => {
+      writePid(String(process.pid))
+      writeSidecarStamp(profileDir, { version: "2.1.1", identity: "abc123" })
+      expect(inspectRunningSidecar(profileDir, "abc123")).toBe("reusable")
     })
   })
 })

--- a/tests/unit/sidecar-profile.test.ts
+++ b/tests/unit/sidecar-profile.test.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import os from "os"
+import { join } from "path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { isProcessAlive, readProfileServerPid, servesOurProfile } from "../../src/lib/joplin-sidecar.js"
+
+// A PID far above any realistic allocation, used to represent a dead process.
+const DEAD_PID = 4_194_303
+
+describe("sidecar profile ownership", () => {
+  let profileDir: string
+
+  beforeEach(() => {
+    profileDir = fs.mkdtempSync(join(os.tmpdir(), "joplin-mcp-test-"))
+  })
+
+  afterEach(() => {
+    fs.rmSync(profileDir, { recursive: true, force: true })
+  })
+
+  const writePid = (contents: string): void => fs.writeFileSync(join(profileDir, "clipper-pid.txt"), contents)
+
+  describe("readProfileServerPid", () => {
+    it("returns none when the profile has no recorded pid", () => {
+      expect(readProfileServerPid(profileDir).isEmpty).toBe(true)
+    })
+
+    it("returns none for a non-numeric pid file", () => {
+      writePid("not-a-pid")
+      expect(readProfileServerPid(profileDir).isEmpty).toBe(true)
+    })
+
+    it("returns none for a non-positive pid", () => {
+      writePid("0")
+      expect(readProfileServerPid(profileDir).isEmpty).toBe(true)
+    })
+
+    it("reads a valid pid, ignoring surrounding whitespace", () => {
+      writePid(" 12345\n")
+      const pid = readProfileServerPid(profileDir).fold(
+        () => null,
+        (v) => v,
+      )
+      expect(pid).toBe(12345)
+    })
+  })
+
+  describe("isProcessAlive", () => {
+    it("detects the current process as alive", () => {
+      expect(isProcessAlive(process.pid)).toBe(true)
+    })
+
+    it("reports an unallocated pid as not alive", () => {
+      expect(isProcessAlive(DEAD_PID)).toBe(false)
+    })
+  })
+
+  describe("servesOurProfile", () => {
+    it("is false when no server pid was ever recorded", () => {
+      expect(servesOurProfile(profileDir)).toBe(false)
+    })
+
+    // The orphan case: a server answering our token while serving a different
+    // profile leaves no live pid in ours, so it must not be reused.
+    it("is false when the recorded server is no longer running", () => {
+      writePid(String(DEAD_PID))
+      expect(servesOurProfile(profileDir)).toBe(false)
+    })
+
+    it("is true when the recorded server is still running", () => {
+      writePid(String(process.pid))
+      expect(servesOurProfile(profileDir)).toBe(true)
+    })
+  })
+})

--- a/tests/unit/sidecar-profile.test.ts
+++ b/tests/unit/sidecar-profile.test.ts
@@ -109,8 +109,11 @@ describe("sidecar profile ownership", () => {
       expect(computeIdentityHash(moved)).not.toBe(computeIdentityHash(base))
     })
 
-    it("changes when the token changes", () => {
-      expect(computeIdentityHash({ ...base, apiToken: "mcp-other" })).not.toBe(computeIdentityHash(base))
+    // The token is intentionally NOT part of identity: reuse is gated by an auth
+    // probe first, so a server with a different token never reaches the identity
+    // comparison. Keeping it out also avoids writing token-derived data to disk.
+    it("ignores the token", () => {
+      expect(computeIdentityHash({ ...base, apiToken: "mcp-other" })).toBe(computeIdentityHash(base))
     })
 
     // The port is resolved dynamically and says nothing about what the server serves,


### PR DESCRIPTION
## Summary

Started from "the joplin MCP tool returns nothing." Root cause was a single-line CLI-flag bug; fixing it surfaced a cluster of related sidecar-lifecycle issues. Five focused commits plus a `2.2.0` bump.

The through-line: **the profile directory is the unit of identity.** One profile = one database = one daemon = one token. Everything that decides "can I reuse this sidecar?" is now a file in that directory rather than something inherited from the environment — so multiple MCP clients (Claude Desktop, Claude Code, a local checkout) either converge on one shared sidecar or stay isolated, purely by `--profile`.

## What was broken

`list_notebooks` returned an empty header while the sync target held 21 notebooks / 212 notes. `--profile` was passed **after** the Joplin CLI subcommand, where it's silently ignored, so the sidecar configured and served the *default* `~/.config/joplin` profile instead of the intended one. No error was ever raised. Three secondary defects turned that transient breakage permanent: token-only reuse adopted broken instances forever, orphaned `joplin server` grandchildren accumulated across sessions, and a memoized `start()` never respawned a dead shared sidecar.

## Commits

1. **Fix sidecar running against the wrong Joplin profile** — move `--profile` before the subcommand (2 sites); require a live server PID in our own profile before reuse; reap the real server (an npx grandchild) on exit/SIGHUP.
2. **Share one sidecar across MCP processes and roll it over on upgrade** — stamp the profile with version + identity hash; adopt only on match, replace on mismatch (this is how upgrades roll the daemon over); discard a settled `start()` when no live server holds the profile, so a client recovers a sidecar it didn't spawn.
3. **Resolve the bundled Joplin CLI relative to this module, not the cwd** — `process.cwd()` is wrong under any packaged/MCPB install; resolve from `import.meta.url` instead, keeping cwd as the last candidate.
4. **Ignore ambient `JOPLIN_TOKEN` in sidecar mode** — it's an external-mode guest credential; sidecar mode mints its own into the profile. Removes the `"JOPLIN_TOKEN": ""` workaround from client configs. Pure, unit-tested resolver.
5. **2.2.0**.

## DX payoff

Client config collapses to just the args — no `env` block:

```json
"joplin": { "command": "npx", "args": ["-y", "joplin-mcp-server@2.2.0",
  "--sync-target", "filesystem", "--sync-path", "~/OneDrive/Apps/Joplin"] }
```

Same `--profile` → shared daemon. Different `--profile` → isolated (e.g. a `joplin-dev` entry).

## Verification

- `pnpm validate` green — 146 tests (was 112), +34 across three new unit suites (profile ownership, upgrade identity, CLI resolution, token resolution).
- Against a real Joplin instance: two clients share one server; a version bump replaces the running sidecar leaving exactly one process; launched with an ambient `JOPLIN_TOKEN`, the sidecar logs the ignore note and configures its own profile token, with the ambient token appearing nowhere in the profile; the built server resolves its CLI from a foreign working directory.

## Breaking

A sidecar-mode token previously pinned via `JOPLIN_TOKEN` must now be passed with `--token`. Niche — sidecar mode auto-generates tokens.

## Follow-ups (not in this PR)

- Publish 2.2.0 (live tools run 2.1.1 from the npx cache until then; CI publishes via OIDC on Node 24).
- MCPB `manifest.json` + packaging-scope decision (vendor `@joplin/*` vs keep npx fallback).
- `.mcp.json` uses a relative `dist/bin.js` — works under Claude Code's cwd, brittle elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)