### PR TITLE
Make the sync tool actually sync in sidecar mode (2.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-mcp-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "MCP server for Joplin",
   "type": "module",
   "main": "dist/index.js",

--- a/src/lib/joplin-sidecar.ts
+++ b/src/lib/joplin-sidecar.ts
@@ -368,6 +368,32 @@ const runJoplinConfig = async (cli: string, profileDir: string, key: string, val
   await execFileAsync(cmd, args, { encoding: "utf-8", timeout: 30_000, shell: isWindows })
 }
 
+// Runs `joplin sync` and returns its captured stdout. The caller must ensure no
+// server is holding the profile (Joplin forbids two instances on one profile).
+const runJoplinSync = async (cli: string, profileDir: string): Promise<string> => {
+  const cmd = cli.endsWith("npx") ? "npx" : cli
+  // --profile must precede the subcommand (see runJoplinConfig).
+  const args = cli.endsWith("npx") ? ["joplin", "--profile", profileDir, "sync"] : ["--profile", profileDir, "sync"]
+  const { stdout } = await execFileAsync(cmd, args, {
+    encoding: "utf-8",
+    timeout: 300_000,
+    shell: isWindows,
+  })
+  return stdout
+}
+
+// Condense Joplin's multi-line sync output to the last meaningful status line,
+// which carries the item counts and duration (e.g. "Created local items: 813...").
+export const summarizeSyncOutput = (stdout: string): string => {
+  const lines = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+  const completed = lines.filter((l) => l.startsWith("Created") || l.startsWith("Fetched") || l.includes("Completed"))
+  const chosen = completed.length > 0 ? completed[completed.length - 1] : lines[lines.length - 1]
+  return chosen ?? "Sync completed."
+}
+
 const configureJoplin = async (cli: string, config: SidecarConfig): Promise<Either<SidecarError, void>> => {
   const settings = buildSettingsRecord(config)
   try {
@@ -801,6 +827,77 @@ export class JoplinSidecar {
     } catch (error) {
       return Left(error instanceof Error ? error : new Error(String(error)))
     }
+  }
+
+  // Release exclusive access to the profile so `joplin sync` can run: Joplin
+  // forbids two instances on one profile. Reaps the recorded server whether we
+  // spawned it or merely adopted a shared one, and resets state so the next
+  // start() performs a full restart.
+  private async releaseProfile(): Promise<void> {
+    this.startPromise = null
+    this.portResolution = null
+    if (this.childProcess) {
+      const proc = this.childProcess
+      try {
+        proc.kill("SIGTERM")
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(() => {
+            proc.kill("SIGKILL")
+            resolve()
+          }, 5000)
+          proc.on("exit", () => {
+            clearTimeout(timeout)
+            resolve()
+          })
+        })
+      } catch {
+        // already gone
+      }
+      this.childProcess = null
+    }
+    this.reapRecordedServer()
+    await this.waitForPortFree(this.config.apiPort)
+  }
+
+  // Triggers a real sync. The clipper server does not sync on its own, so this
+  // stops the server, runs `joplin sync`, then restarts it. Brief downtime (the
+  // sync duration) during which tool calls will re-establish the server.
+  async sync(): Promise<Either<SidecarError, string>> {
+    const cliResult = await findJoplinCli()
+    if (Either.isLeft(cliResult)) {
+      return Left(
+        cliResult.fold(
+          (e) => e,
+          () => null as never,
+        ),
+      )
+    }
+    const cli = cliResult.fold(
+      () => "",
+      (v) => v,
+    )
+
+    await this.releaseProfile()
+
+    const syncResult = await (async (): Promise<Either<SidecarError, string>> => {
+      try {
+        return Right(summarizeSyncOutput(await runJoplinSync(cli, this.config.profileDir)))
+      } catch (e) {
+        return Left(sidecarError("SYNC_FAILED", "joplin sync failed", e))
+      }
+    })()
+
+    // Bring the server back regardless of whether the sync succeeded.
+    const restart = await this.start()
+    if (Either.isRight(syncResult) && Either.isLeft(restart)) {
+      return Left(
+        restart.fold(
+          (e) => sidecarError("SYNC_FAILED", `Sync completed but the server failed to restart: ${e.message}`, e),
+          () => null as never,
+        ),
+      )
+    }
+    return syncResult
   }
 
   async healthCheck(): Promise<Either<Error, true>> {

--- a/src/server-core.ts
+++ b/src/server-core.ts
@@ -189,18 +189,28 @@ export class JoplinServerManager {
       ? "\n\nNote: Joplin Desktop is also running. The sidecar and Desktop use separate databases. " +
         "Notes sync between them only if both are configured with the same sync target."
       : ""
-    // Try triggering sync via the Joplin REST API (POST /services/sync)
+
+    // Sidecar mode: the clipper server does not sync on its own, so drive a real
+    // sync through the CLI (stop server, sync, restart).
+    if (this.config.sidecar) {
+      const result = await this.config.sidecar.sync()
+      // Re-validate the connection after the stop/restart. The restart reclaims the
+      // same freed port, so the existing client keeps working.
+      this.connected = false
+      await this.ensureConnected()
+      return result.fold(
+        (error) => `Sync failed: ${error.message}${desktopWarning}`,
+        (summary) => `Sync complete. ${summary}${desktopWarning}`,
+      )
+    }
+
+    // External mode (connected to e.g. Joplin Desktop): trigger via the REST API.
     const result = await this.apiClient.post<Record<string, unknown>>("/services/sync", { action: "start" })
     return result.fold(
       (error) => {
         const msg = error.message || String(error)
-        // 404 or "No action API" = Joplin instance doesn't expose sync as a REST service
-        // This is normal for Joplin Terminal CLI — it auto-syncs on its configured interval
         if (msg.includes("404") || msg.includes("No action API") || msg.includes("No such service")) {
-          return (
-            `Sync is managed automatically by the Joplin server on its configured interval ` +
-            `(default: every 5 minutes). On-demand sync is not available via the Joplin Terminal API.${desktopWarning}`
-          )
+          return `On-demand sync is not available on this Joplin instance.${desktopWarning}`
         }
         return `Sync failed: ${msg}${desktopWarning}`
       },

--- a/tests/unit/sidecar-profile.test.ts
+++ b/tests/unit/sidecar-profile.test.ts
@@ -9,6 +9,7 @@ import {
   isProcessAlive,
   localCliCandidates,
   readProfileServerPid,
+  summarizeSyncOutput,
   readSidecarStamp,
   servesOurProfile,
   writeSidecarStamp,
@@ -191,6 +192,32 @@ describe("sidecar profile ownership", () => {
 
     it("still searches the working directory for local development", () => {
       expect(localCliCandidates()).toContain(join(process.cwd(), "node_modules", ".bin", CLI_BIN_NAME))
+    })
+  })
+
+  describe("summarizeSyncOutput", () => {
+    it("picks the final item-count line from real joplin output", () => {
+      const out = [
+        "Synchronisation target:  (2)",
+        "Starting synchronisation...",
+        "Fetched items: 1/50.",
+        "Downloading resources...",
+        "Created local items: 813. Fetched items: 813/813. Completed: 23/07/2026 22:06 (3s)",
+      ].join("\n")
+      expect(summarizeSyncOutput(out)).toContain("Created local items: 813")
+    })
+
+    it("prefers a Completed line when present", () => {
+      const out = "Starting synchronisation...\nCompleted: 23/07/2026 22:06 (0s)"
+      expect(summarizeSyncOutput(out)).toContain("Completed")
+    })
+
+    it("falls back to the last non-empty line when no count line exists", () => {
+      expect(summarizeSyncOutput("Starting synchronisation...\nNothing to sync\n\n")).toBe("Nothing to sync")
+    })
+
+    it("returns a default for empty output", () => {
+      expect(summarizeSyncOutput("   \n  \n")).toBe("Sync completed.")
     })
   })
 })


### PR DESCRIPTION
## Summary

The `sync` tool was a no-op that reported success. It told users *"Sync is managed automatically… every 5 minutes,"* but the Joplin clipper server (`server start`) **does not run the periodic sync scheduler** — I watched an empty profile stay empty for 6.5 minutes — and exposes no on-demand sync endpoint. So a profile could silently go stale while the tool claimed all was well. This is the root cause of the "joplin returns nothing" symptom resurfacing after a profile reset.

## Fix

Joplin forbids two instances on one profile (its own `server` help recommends a separate profile so *"no two CLI instances access that profile at the same time"*), so sync can't run alongside the clipper server. `JoplinSidecar.sync()` now:

1. Releases the profile — reaping the recorded server PID whether we spawned it or adopted a shared one, so the shared-sidecar case is handled.
2. Runs `joplin --profile <dir> sync`.
3. Restarts the server and reconnects.
4. Returns Joplin's own item-count summary (e.g. `Created local items: 813...`).

Downtime is the sync duration (~3s for ~213 notes); tool calls during the window re-establish the server via the existing respawn logic.

**External mode unchanged** — still tries the REST sync endpoint for a real Joplin (e.g. Desktop) that supports it.

## Verification

- `pnpm validate` green — 150 tests (+4: `summarizeSyncOutput` parsing).
- End to end over the MCP protocol against a fresh profile: `sync` reports `Created local items: 813. Fetched items: 813/813 (3s)`, and `list_notebooks` immediately returns the full hierarchy (212 notes / 21 folders).

## Note

`2.2.1`. Depends on 2.2.0 (this branch is cut from it). Related follow-up: the `sync` tool description could mention the brief restart. Publish via tag `v2.2.1` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)