### PR TITLE
Add MCPB bundle for one-click Claude Desktop install (2.2.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ coverage/
 **/.claude/settings.local.json
 
 .idea/
+
+# MCPB bundle build
+.mcpb-build/
+*.mcpb

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,111 @@
+{
+  "manifest_version": "0.4",
+  "name": "joplin-mcp-server",
+  "display_name": "Joplin",
+  "version": "2.2.2",
+  "description": "Search, read, create, and edit Joplin notes and notebooks over the Model Context Protocol.",
+  "long_description": "An MCP server for the [Joplin](https://joplinapp.org) note-taking app. It runs a self-managed Joplin sidecar (a headless Joplin terminal instance) against a sync target you already use \u2014 no separate Joplin app needs to be running. Provides tools to list notebooks, search notes, read/create/edit/delete notes and folders, and trigger an on-demand sync.\n\nBy default it syncs from a **filesystem** target (a folder that Joplin Desktop/mobile already syncs to). Point `Sync path` at that folder and the server pulls your notes into its own profile.",
+  "author": {
+    "name": "Jordan Burke",
+    "email": "jordan.burke@gmail.com",
+    "url": "https://github.com/jordanburke"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jordanburke/joplin-mcp-server.git"
+  },
+  "homepage": "https://github.com/jordanburke/joplin-mcp-server#readme",
+  "documentation": "https://github.com/jordanburke/joplin-mcp-server#readme",
+  "support": "https://github.com/jordanburke/joplin-mcp-server/issues",
+  "license": "MIT",
+  "keywords": ["joplin", "notes", "notebooks", "note-taking", "markdown"],
+  "server": {
+    "type": "node",
+    "entry_point": "server/bin.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/server/bin.js",
+        "--sync-target",
+        "filesystem",
+        "--sync-path",
+        "${user_config.sync_path}",
+        "--profile",
+        "${user_config.profile_dir}"
+      ]
+    }
+  },
+  "tools": [
+    {
+      "name": "list_notebooks",
+      "description": "Retrieve the complete notebook hierarchy"
+    },
+    {
+      "name": "search_notes",
+      "description": "Search notes and return matching notebooks"
+    },
+    {
+      "name": "read_notebook",
+      "description": "Read the notes in a notebook"
+    },
+    {
+      "name": "read_note",
+      "description": "Read a single note by id"
+    },
+    {
+      "name": "read_multinote",
+      "description": "Read multiple notes by id"
+    },
+    {
+      "name": "create_note",
+      "description": "Create a note"
+    },
+    {
+      "name": "create_folder",
+      "description": "Create a notebook (folder)"
+    },
+    {
+      "name": "edit_note",
+      "description": "Edit an existing note"
+    },
+    {
+      "name": "edit_folder",
+      "description": "Rename or move a notebook"
+    },
+    {
+      "name": "delete_note",
+      "description": "Delete a note"
+    },
+    {
+      "name": "delete_folder",
+      "description": "Delete a notebook"
+    },
+    {
+      "name": "sync",
+      "description": "Trigger an on-demand sync with the configured sync target"
+    }
+  ],
+  "tools_generated": false,
+  "user_config": {
+    "sync_path": {
+      "type": "directory",
+      "title": "Sync path",
+      "description": "The filesystem folder your Joplin already syncs to (Joplin: Configuration > Synchronisation > 'File system', Directory). The server reads your notes from here.",
+      "required": true
+    },
+    "profile_dir": {
+      "type": "directory",
+      "title": "Sidecar profile directory",
+      "description": "Where the server keeps its own headless Joplin profile. Leave the default unless you want to isolate this instance from other clients sharing the same profile.",
+      "default": "${HOME}/.config/joplin-mcp",
+      "required": false
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "node": ">=18.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-mcp-server",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "MCP server for Joplin",
   "type": "module",
   "main": "dist/index.js",
@@ -19,7 +19,8 @@
   "files": [
     "dist/",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "manifest.json"
   ],
   "scripts": {
     "validate": "ts-builds validate",
@@ -52,7 +53,8 @@
     "test:manual:delete-folder": "tsx tests/manual/delete-folder.test.ts",
     "test:manual:list-notebooks": "tsx tests/manual/list-notebooks.test.ts",
     "docker:build": "docker build -t joplin-mcp .",
-    "docker:run": "docker run -e JOPLIN_TOKEN=$JOPLIN_TOKEN -p 3000:3000 joplin-mcp"
+    "docker:run": "docker run -e JOPLIN_TOKEN=$JOPLIN_TOKEN -p 3000:3000 joplin-mcp",
+    "build:mcpb": "pnpm build && node scripts/build-mcpb.mjs"
   },
   "prettier": "ts-builds/prettier",
   "keywords": [

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Builds a self-contained .mcpb bundle: the built server plus a production-only
+// node_modules (including the Joplin CLI, which the sidecar spawns). Packing the
+// repo root directly would zip the entire dev tree, so we stage a clean directory
+// and run a fresh production install there.
+import { execFileSync } from "child_process"
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs"
+import { dirname, join } from "path"
+import { fileURLToPath } from "url"
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..")
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
+const stage = join(root, ".mcpb-build")
+const out = join(root, `${pkg.name}-${pkg.version}.mcpb`)
+
+const run = (cmd, args, cwd) => execFileSync(cmd, args, { cwd, stdio: "inherit" })
+
+if (!existsSync(join(root, "dist", "bin.js"))) {
+  throw new Error("dist/ is not built — run `pnpm build` first")
+}
+
+console.log("• Staging clean build directory")
+rmSync(stage, { recursive: true, force: true })
+mkdirSync(join(stage, "server"), { recursive: true })
+
+console.log("• Copying built server → server/")
+cpSync(join(root, "dist"), join(stage, "server"), { recursive: true })
+
+console.log("• Writing production package.json")
+writeFileSync(
+  join(stage, "package.json"),
+  JSON.stringify({ name: pkg.name, version: pkg.version, type: "module", dependencies: pkg.dependencies }, null, 2) +
+    "\n",
+)
+
+console.log("• Installing production dependencies (this pulls the Joplin CLI)")
+run("npm", ["install", "--omit=dev", "--no-audit", "--no-fund", "--loglevel=error"], stage)
+
+console.log("• Copying manifest.json")
+cpSync(join(root, "manifest.json"), join(stage, "manifest.json"))
+
+console.log("• Packing .mcpb")
+run("npx", ["-y", "@anthropic-ai/mcpb", "pack", stage, out], root)
+
+console.log(`\n✓ Built ${out}`)

--- a/src/lib/joplin-sidecar.ts
+++ b/src/lib/joplin-sidecar.ts
@@ -275,10 +275,29 @@ const ancestorDirs = (dir: string, remaining: number): string[] => {
   return [dir, ...ancestorDirs(parent, remaining - 1)]
 }
 
-const localCliCandidates = (): string[] =>
-  [...ancestorDirs(dirname(fileURLToPath(import.meta.url)), CLI_SEARCH_DEPTH), process.cwd()].map((root) =>
+// Candidate CLI locations, nearest first, two forms per root:
+//   node_modules/.bin/joplin     — a normal install (a symlink/shim)
+//   node_modules/joplin/main.js  — the package's own entry, used when .bin symlinks
+//                                  were stripped (e.g. inside a packed .mcpb bundle)
+const localCliCandidates = (): string[] => {
+  const roots = [...ancestorDirs(dirname(fileURLToPath(import.meta.url)), CLI_SEARCH_DEPTH), process.cwd()]
+  return roots.flatMap((root) => [
     join(root, "node_modules", ".bin", CLI_BIN_NAME),
-  )
+    join(root, "node_modules", "joplin", "main.js"),
+  ])
+}
+
+// How to invoke a resolved Joplin CLI. Three shapes:
+//   *.js  → `node <entry> <args>`  (package main, e.g. from a packed bundle; run via
+//           the current Node binary since PATH is not guaranteed in a host sandbox)
+//   npx   → `npx joplin <args>`    (last-resort fallback that may download)
+//   else  → `<cli> <args>`         (a .bin shim / executable)
+// shell is only needed for npx/.cmd on Windows.
+const joplinInvocation = (cli: string, subArgs: string[]): { cmd: string; args: string[]; shell: boolean } => {
+  if (cli.endsWith(".js")) return { cmd: process.execPath, args: [cli, ...subArgs], shell: false }
+  if (cli.endsWith("npx")) return { cmd: "npx", args: ["joplin", ...subArgs], shell: isWindows }
+  return { cmd: cli, args: subArgs, shell: isWindows }
+}
 
 const findJoplinCli = async (): Promise<Either<SidecarError, string>> => {
   // 1. User override via env var
@@ -359,26 +378,18 @@ const buildSettingsRecord = (config: SidecarConfig): Record<string, string> => {
 }
 
 const runJoplinConfig = async (cli: string, profileDir: string, key: string, value: string): Promise<void> => {
-  const cmd = cli.endsWith("npx") ? "npx" : cli
   // --profile is a global flag: it must precede the subcommand or the CLI
   // silently ignores it and falls back to the default ~/.config/joplin profile.
-  const args = cli.endsWith("npx")
-    ? ["joplin", "--profile", profileDir, "config", key, value]
-    : ["--profile", profileDir, "config", key, value]
-  await execFileAsync(cmd, args, { encoding: "utf-8", timeout: 30_000, shell: isWindows })
+  const { cmd, args, shell } = joplinInvocation(cli, ["--profile", profileDir, "config", key, value])
+  await execFileAsync(cmd, args, { encoding: "utf-8", timeout: 30_000, shell })
 }
 
 // Runs `joplin sync` and returns its captured stdout. The caller must ensure no
 // server is holding the profile (Joplin forbids two instances on one profile).
 const runJoplinSync = async (cli: string, profileDir: string): Promise<string> => {
-  const cmd = cli.endsWith("npx") ? "npx" : cli
   // --profile must precede the subcommand (see runJoplinConfig).
-  const args = cli.endsWith("npx") ? ["joplin", "--profile", profileDir, "sync"] : ["--profile", profileDir, "sync"]
-  const { stdout } = await execFileAsync(cmd, args, {
-    encoding: "utf-8",
-    timeout: 300_000,
-    shell: isWindows,
-  })
+  const { cmd, args, shell } = joplinInvocation(cli, ["--profile", profileDir, "sync"])
+  const { stdout } = await execFileAsync(cmd, args, { encoding: "utf-8", timeout: 300_000, shell })
   return stdout
 }
 
@@ -409,16 +420,13 @@ const configureJoplin = async (cli: string, config: SidecarConfig): Promise<Eith
 
 const spawnServer = (cli: string, config: SidecarConfig): Either<SidecarError, ChildProcess> => {
   try {
-    const cmd = cli.endsWith("npx") ? "npx" : cli
     // --profile must precede the subcommand (see runJoplinConfig).
-    const args = cli.endsWith("npx")
-      ? ["joplin", "--profile", config.profileDir, "server", "start"]
-      : ["--profile", config.profileDir, "server", "start"]
+    const { cmd, args, shell } = joplinInvocation(cli, ["--profile", config.profileDir, "server", "start"])
 
     const proc = spawn(cmd, args, {
       stdio: ["ignore", "pipe", "pipe"],
       detached: false,
-      shell: isWindows,
+      shell,
     })
 
     proc.stderr.on("data", (data: Buffer) => {

--- a/tests/unit/sidecar-profile.test.ts
+++ b/tests/unit/sidecar-profile.test.ts
@@ -171,9 +171,8 @@ describe("sidecar profile ownership", () => {
   })
 
   describe("localCliCandidates", () => {
-    it("looks for the CLI in node_modules/.bin", () => {
-      const suffix = join("node_modules", ".bin")
-      expect(localCliCandidates().every((p) => p.includes(suffix))).toBe(true)
+    it("looks under node_modules", () => {
+      expect(localCliCandidates().every((p) => p.includes(join("node_modules")))).toBe(true)
     })
 
     // The packaged-install failure: the host application sets the working
@@ -192,6 +191,12 @@ describe("sidecar profile ownership", () => {
 
     it("still searches the working directory for local development", () => {
       expect(localCliCandidates()).toContain(join(process.cwd(), "node_modules", ".bin", CLI_BIN_NAME))
+    })
+
+    // A packed .mcpb strips node_modules/.bin symlinks, so resolution must also
+    // target the joplin package's own entry (main.js), invoked via `node`.
+    it("includes the joplin package main entry as a fallback for stripped .bin", () => {
+      expect(localCliCandidates()).toContain(join(process.cwd(), "node_modules", "joplin", "main.js"))
     })
   })
 


### PR DESCRIPTION
## Summary

Adds a **Claude Desktop one-click bundle** (`.mcpb`) for the server, plus the CLI-resolution fix needed to make a packed bundle actually run.

## What's in the bundle

- **`manifest.json`** (MCPB 0.4, passes `mcpb validate`): runs the bundled server via `node ${__dirname}/server/bin.js`, exposes `sync_path` (required) and `profile_dir` (optional, default `${HOME}/.config/joplin-mcp`) as `user_config`, and declares all 12 tools. **No `env` block** — sidecar mode manages its own token, the DX payoff from the 2.2.0 token work.
- **`scripts/build-mcpb.mjs`** + **`pnpm build:mcpb`**: the repo's dev `node_modules` is ~3 GB, so packing the root isn't viable. The script stages a clean directory, runs a fresh `npm install --omit=dev` (which pulls the Joplin CLI), and packs a `.mcpb`. Result: **~55 MB packed / ~177 MB unpacked**, dominated by the Joplin CLI's dependency tree (xmlbuilder, yargs, xml2js, …).

## The fix that made it work

`mcpb pack` **strips `node_modules/.bin` symlinks**. The previous CLI lookup only checked `.bin/joplin`, so inside a bundle it fell through to npx — which isn't available in the Desktop sandbox → the sidecar would fail to start.

Resolution now also targets the joplin package's own entry (`node_modules/joplin/main.js`) and invokes any `.js` entry via the current Node binary (`process.execPath`) rather than relying on PATH. This composes with the earlier module-relative lookup, so CLI resolution works from `src/` (Vitest), `dist/` (npm), and inside a packed bundle.

## Packaging-scope decision (previously open)

Resolved: **bundle the Joplin CLI**. There's no npx guarantee in the Desktop extension sandbox, so a self-contained bundle must ship it. The npx fallback stays only as a last resort for non-bundled installs.

## Verification

- `pnpm validate` green — 151 tests (+1: joplin `main.js` candidate).
- `mcpb validate manifest.json` → *"Manifest schema validation passes!"*
- Built the `.mcpb`, unpacked it, and ran `server/bin.js` from an **unrelated working directory**: resolves `.../node_modules/joplin/main.js` (not npx), configures the profile, reports server ready. Confirmed `.bin/` is absent from the packed archive while `joplin/main.js` is present.

## Notes

- `2.2.2`. The `main.js` resolution is a genuine robustness improvement for the published npm package too, not only the bundle.
- The `.mcpb` artifact itself is gitignored (built on demand via `pnpm build:mcpb`); it is not committed or published to npm. Attaching it to a GitHub Release is the natural distribution path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)